### PR TITLE
add deregisterField method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ override func viewDidLoad() {
 	validator.registerField(phoneNumberTextField, errorLabel: phoneNumberErrorLabel, rules: [RequiredRule(), MinLengthRule(length: 9)])
 	validator.registerField(zipcodeTextField, errorLabel: zipcodeErrorLabel, rules: [RequiredRule(), ZipCodeRule(regex = "\\d{5}")])
 
+	// You can unregister a text field if you no longer want to validate it
+	validator.unregisterField(fullNameTextField)
 }
 ```
 

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -31,6 +31,10 @@ public class Validator {
         validations[textField] = ValidationRule(textField: textField, rules:rules, errorLabel:errorLabel)
     }
     
+    public func deregisterField(textField:UITextField) {
+        validations.removeValueForKey(textField)
+    }
+    
     public func validate(delegate:ValidationDelegate) {
         
         for field in validations.keys {

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -31,7 +31,7 @@ public class Validator {
         validations[textField] = ValidationRule(textField: textField, rules:rules, errorLabel:errorLabel)
     }
     
-    public func deregisterField(textField:UITextField) {
+    public func unregisterField(textField:UITextField) {
         validations.removeValueForKey(textField)
     }
     

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -31,6 +31,14 @@ class ValidatorTests: XCTestCase {
     let LEN_5 = "Howdy"
     let LEN_20 = "Paint the cat orange"
     
+    let REGISTER_TXT_FIELD = UITextField()
+    let REGISTER_VALIDATOR = Validator()
+    let REGISTER_RULES = [Rule]()
+    
+    let UNREGISTER_TXT_FIELD = UITextField()
+    let UNREGISTER_VALIDATOR = Validator()
+    let UNREGISTER_RULES = [Rule]()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -144,4 +152,16 @@ class ValidatorTests: XCTestCase {
         XCTAssertFalse(FullNameRule().validate("Carl"), "Full Name should be invalid")
     }
     
+    // MARK: Register Field
+    
+    func testRegisterField(){
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, rules: REGISTER_RULES)
+        XCTAssert(REGISTER_VALIDATOR.validations[REGISTER_TXT_FIELD] != nil, "Textfield should register")
+    }
+    
+    func testUnregisterField(){
+        UNREGISTER_VALIDATOR.registerField(UNREGISTER_TXT_FIELD, rules: UNREGISTER_RULES)
+        UNREGISTER_VALIDATOR.unregisterField(UNREGISTER_TXT_FIELD)
+        XCTAssert(UNREGISTER_VALIDATOR.validations[UNREGISTER_TXT_FIELD] == nil, "Textfield should unregister")
+    }
 }


### PR DESCRIPTION
Add a `deregisterField` method that allows to remove a text field from validation.