### PR TITLE
Fix issue with errors showing up for unregistered fields

### DIFF
--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -33,6 +33,7 @@ public class Validator {
     
     public func unregisterField(textField:UITextField) {
         validations.removeValueForKey(textField)
+        errors.removeValueForKey(textField)
     }
     
     public func validate(delegate:ValidationDelegate) {

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -39,6 +39,9 @@ class ValidatorTests: XCTestCase {
     let UNREGISTER_VALIDATOR = Validator()
     let UNREGISTER_RULES = [Rule]()
     
+    let UNREGISTER_ERRORS_TXT_FIELD = UITextField()
+    let UNREGISTER_ERRORS_VALIDATOR = Validator()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -163,6 +166,18 @@ class ValidatorTests: XCTestCase {
         UNREGISTER_VALIDATOR.registerField(UNREGISTER_TXT_FIELD, rules: UNREGISTER_RULES)
         UNREGISTER_VALIDATOR.unregisterField(UNREGISTER_TXT_FIELD)
         XCTAssert(UNREGISTER_VALIDATOR.validations[UNREGISTER_TXT_FIELD] == nil, "Textfield should unregister")
+    }
+    
+    func testUnregisterError(){
+        UNREGISTER_ERRORS_VALIDATOR.registerField(UNREGISTER_ERRORS_TXT_FIELD, rules: [EmailRule()])
+        UNREGISTER_ERRORS_TXT_FIELD.text = INVALID_EMAIL
+        UNREGISTER_ERRORS_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+        }
+        UNREGISTER_ERRORS_VALIDATOR.unregisterField(UNREGISTER_ERRORS_TXT_FIELD)
+        UNREGISTER_ERRORS_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 0, "Should not come back with errors")
+        }
     }
     
     // MARK: Validate Functions


### PR DESCRIPTION
This fixes an issue with errors showing up for unregistered text fields, if they have been validated before.
An example:

    let myTextField = UITextField()
    let myValidator = Validator()
    
    // registering field
    myValidator.registerField(myTextField, rules: [EmailRule()])
    
    // setting an invalid email address
    myTextField.text = "myinvalidemail"
   
    // validating field
    myValidator.validate { (errors) -> Void in
        println(errors.count) // prints 1
    }

    // unregistering field:
    myValidator.unregisterField(myTextField)

    // validating again
    myValidator.validate { (errors) -> Void in
        println(errors.count) // currently prints 1, but should print 0.
    }
    