### PR TITLE
FloatRule, style transform callback on success/error

### DIFF
--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		62DC8D6E1AAA42CE0095DFA7 /* PasswordRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DC8D6B1AAA42CE0095DFA7 /* PasswordRule.swift */; };
 		62DC8D711AAA43110095DFA7 /* ZipCodeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */; };
 		62E9E2AD1ACFB336000A939C /* RegexRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9E2AC1ACFB336000A939C /* RegexRule.swift */; };
+		DC5A35EC1AF99BA60013FE6B /* FloatRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,7 @@
 		62DC8D6B1AAA42CE0095DFA7 /* PasswordRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordRule.swift; sourceTree = "<group>"; };
 		62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipCodeRule.swift; sourceTree = "<group>"; };
 		62E9E2AC1ACFB336000A939C /* RegexRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexRule.swift; sourceTree = "<group>"; };
+		DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +173,7 @@
 				62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */,
 				628637271AAA49E300BC8FCF /* ConfirmRule.swift */,
 				62E9E2AC1ACFB336000A939C /* RegexRule.swift */,
+				DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */,
 			);
 			name = Rules;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 				628637281AAA49E300BC8FCF /* ConfirmRule.swift in Sources */,
 				62DC8D651AAA42520095DFA7 /* Rule.swift in Sources */,
 				62D1AE1F1A1E6D4400E4DFF8 /* ViewController.swift in Sources */,
+				DC5A35EC1AF99BA60013FE6B /* FloatRule.swift in Sources */,
 				62DC8D6D1AAA42CE0095DFA7 /* RequiredRule.swift in Sources */,
 				62D1AE1D1A1E6D4400E4DFF8 /* AppDelegate.swift in Sources */,
 				62D1AE581A1E700200E4DFF8 /* Validator.swift in Sources */,

--- a/Validator/FloatRule.swift
+++ b/Validator/FloatRule.swift
@@ -1,0 +1,29 @@
+//
+//  FloatRule.swift
+//  Validator
+//
+//  Created by Cameron McCord on 5/5/15.
+//  Copyright (c) 2015 jpotts18. All rights reserved.
+//
+
+import Foundation
+
+public class FloatRule:Rule {
+    
+    public init(){
+        
+    }
+    
+    public func validate(value: String) -> Bool {
+        let regex = NSRegularExpression(pattern: "[-+]?(\\d*[.])?\\d+", options: nil, error: nil)
+        if let regex = regex {
+            let match = regex.numberOfMatchesInString(value, options: nil, range: NSRange(location: 0, length: count(value)))
+            return match == 1
+        }
+        return false
+    }
+    
+    public func errorMessage() -> String {
+        return "This must be a number with or without a decimal"
+    }
+}

--- a/Validator/ValidationError.swift
+++ b/Validator/ValidationError.swift
@@ -18,4 +18,10 @@ public class ValidationError {
         self.textField = textField
         self.errorMessage = error
     }
+    
+    public init(textField:UITextField, errorLabel:UILabel?, error:String){
+        self.textField = textField
+        self.errorLabel = errorLabel
+        self.errorMessage = error
+    }
 }

--- a/Validator/ValidationRule.swift
+++ b/Validator/ValidationRule.swift
@@ -23,7 +23,7 @@ public class ValidationRule {
     public func validateField() -> ValidationError? {
         for rule in rules {
             if !rule.validate(textField.text) {
-                return ValidationError(textField: self.textField, error: rule.errorMessage())
+                return ValidationError(textField: self.textField, errorLabel:self.errorLabel, error: rule.errorMessage())
             }
         }
         return nil

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -42,6 +42,11 @@ public class Validator {
         field.layer.borderWidth = 1.0
     }
     
+    private func unmarkTextFieldAsInError(field:UITextField) {
+        field.layer.borderColor = UIColor.clearColor().CGColor
+        field.layer.borderWidth = 0.0
+    }
+    
     public func validate(delegate:ValidationDelegate) {
         
         for field in validations.keys {
@@ -58,6 +63,9 @@ public class Validator {
                     errors.removeValueForKey(field)
                     if let errorLabel = currentRule.errorLabel {
                         errorLabel.text = nil
+                    }
+                    if shouldMarkTextFieldsInError {
+                        self.unmarkTextFieldAsInError(field)
                     }
                 }
             }
@@ -86,6 +94,9 @@ public class Validator {
                     errors.removeValueForKey(field)
                     if let errorLabel = currentRule.errorLabel {
                         errorLabel.text = nil
+                    }
+                    if shouldMarkTextFieldsInError {
+                        self.unmarkTextFieldAsInError(field)
                     }
                 }
             }

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -19,7 +19,6 @@ public class Validator {
     public var errors:[UITextField:ValidationError] = [:]
     public var validations:[UITextField:ValidationRule] = [:]
     public var shouldMarkTextFieldsInError:Bool = false
-    public var textFieldErrorColor:UIColor = UIColor.redColor()
     
     public init(){}
     
@@ -39,7 +38,7 @@ public class Validator {
     }
     
     private func markTextFieldAsInError(field:UITextField) {
-        field.layer.borderColor = self.textFieldErrorColor.CGColor
+        field.layer.borderColor = UIColor.redColor().CGColor
         field.layer.borderWidth = 1.0
     }
     

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -18,7 +18,7 @@ public class Validator {
     // dictionary to handle complex view hierarchies like dynamic tableview cells
     public var errors:[UITextField:ValidationError] = [:]
     public var validations:[UITextField:ValidationRule] = [:]
-    public var markTextFieldsInError:Bool = false
+    public var shouldMarkTextFieldsInError:Bool = false
     public var textFieldErrorColor:UIColor = UIColor.redColor()
     
     public init(){}
@@ -51,7 +51,7 @@ public class Validator {
                     if let errorLabel = currentRule.errorLabel {
                         errorLabel.text = error.errorMessage
                     }
-                    if markTextFieldsInError {
+                    if shouldMarkTextFieldsInError {
                         self.markTextFieldAsInError(field)
                     }
                     errors[field] = error
@@ -79,7 +79,7 @@ public class Validator {
                     if let errorLabel = currentRule.errorLabel {
                         errorLabel.text = error.errorMessage
                     }
-                    if markTextFieldsInError {
+                    if shouldMarkTextFieldsInError {
                         self.markTextFieldAsInError(field)
                     }
                     errors[field] = error

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -31,6 +31,8 @@ public class Validator {
     
     private func validateAllFields() {
         
+        self.clearErrors()
+        
         for field in validations.keys {
             if let currentRule: ValidationRule = validations[field] {
                 if var error: ValidationError = currentRule.validateField() {
@@ -72,8 +74,6 @@ public class Validator {
     }
     
     public func validate(delegate:ValidationDelegate) {
-        
-        self.clearErrors()
         
         self.validateAllFields()
         

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -18,6 +18,8 @@ public class Validator {
     // dictionary to handle complex view hierarchies like dynamic tableview cells
     public var errors:[UITextField:ValidationError] = [:]
     public var validations:[UITextField:ValidationRule] = [:]
+    public var markTextFieldsInError:Bool = false
+    public var textFieldErrorColor:UIColor = UIColor.redColor()
     
     public init(){}
     
@@ -36,17 +38,28 @@ public class Validator {
         errors.removeValueForKey(textField)
     }
     
+    private func markTextFieldAsInError(field:UITextField) {
+        field.layer.borderColor = self.textFieldErrorColor.CGColor
+        field.layer.borderWidth = 1.0
+    }
+    
     public func validate(delegate:ValidationDelegate) {
         
         for field in validations.keys {
             if let currentRule: ValidationRule = validations[field] {
                 if var error: ValidationError = currentRule.validateField() {
-                    if currentRule.errorLabel != nil {
-                        error.errorLabel = currentRule.errorLabel
+                    if let errorLabel = currentRule.errorLabel {
+                        errorLabel.text = error.errorMessage
+                    }
+                    if markTextFieldsInError {
+                        self.markTextFieldAsInError(field)
                     }
                     errors[field] = error
                 } else {
                     errors.removeValueForKey(field)
+                    if let errorLabel = currentRule.errorLabel {
+                        errorLabel.text = nil
+                    }
                 }
             }
         }
@@ -63,9 +76,18 @@ public class Validator {
         for field in validations.keys {
             if let currentRule:ValidationRule = validations[field] {
                 if var error:ValidationError = currentRule.validateField() {
+                    if let errorLabel = currentRule.errorLabel {
+                        errorLabel.text = error.errorMessage
+                    }
+                    if markTextFieldsInError {
+                        self.markTextFieldAsInError(field)
+                    }
                     errors[field] = error
                 } else {
                     errors.removeValueForKey(field)
+                    if let errorLabel = currentRule.errorLabel {
+                        errorLabel.text = nil
+                    }
                 }
             }
         }

--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -37,8 +37,9 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
             println("here")
                 // clear error label
                 validationRule.errorLabel?.hidden = true
-                validationRule.textField.layer.borderColor = UIColor.clearColor().CGColor
-                validationRule.textField.layer.borderWidth = 0.0
+                validationRule.errorLabel?.text = ""
+                validationRule.textField.layer.borderColor = UIColor.greenColor().CGColor
+                validationRule.textField.layer.borderWidth = 0.5
             
             }, error:{ (validationError) -> Void in
                 println("error")
@@ -57,7 +58,6 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
 
     @IBAction func submitTapped(sender: AnyObject) {
         println("Validating...")
-//        self.clearErrors()
         validator.validate(self)
     }
 
@@ -73,38 +73,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
     }
     func validationFailed(errors:[UITextField:ValidationError]) {
         println("Validation FAILED!")
-//        self.setErrors()
     }
-    
-    // MARK: Error Styling
-    
-//    func removeError(label:UILabel, textField:UITextField) {
-//        label.hidden = true
-//        textField.layer.borderWidth = 0.0
-//    }
-    
-//    func removeAllErrors(){
-//        removeError(fullNameErrorLabel, textField: fullNameTextField)
-//        removeError(emailErrorLabel, textField: emailTextField)
-//        removeError(phoneNumberErrorLabel, textField: phoneNumberTextField)
-//        removeError(zipcodeErrorLabel, textField: zipcodeTextField)
-//    }
-    
-//    private func setErrors(){
-//        for (field, error) in validator.errors {
-//            field.layer.borderColor = UIColor.redColor().CGColor
-//            field.layer.borderWidth = 1.0
-//            error.errorLabel?.text = error.errorMessage
-//            error.errorLabel?.hidden = false
-//        }
-//    }
-    
-//    private func clearErrors(){
-//        for (field, error) in validator.errors {
-//            field.layer.borderWidth = 0.0
-//            error.errorLabel?.hidden = true
-//        }
-//    }
     
     func hideKeyboard(){
         self.view.endEditing(true)

--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -33,6 +33,21 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
         
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: "hideKeyboard"))
         
+        validator.styleTransformers(success:{ (validationRule) -> Void in
+            println("here")
+                // clear error label
+                validationRule.errorLabel?.hidden = true
+                validationRule.textField.layer.borderColor = UIColor.clearColor().CGColor
+                validationRule.textField.layer.borderWidth = 0.0
+            
+            }, error:{ (validationError) -> Void in
+                println("error")
+                validationError.errorLabel?.hidden = false
+                validationError.errorLabel?.text = validationError.errorMessage
+                validationError.textField.layer.borderColor = UIColor.redColor().CGColor
+                validationError.textField.layer.borderWidth = 1.0
+        })
+        
         validator.registerField(fullNameTextField, errorLabel: fullNameErrorLabel , rules: [RequiredRule(), FullNameRule()])
         validator.registerField(emailTextField, errorLabel: emailErrorLabel, rules: [RequiredRule(), EmailRule()])
         validator.registerField(emailConfirmTextField, errorLabel: emailConfirmErrorLabel, rules: [RequiredRule(), ConfirmationRule(confirmField: emailTextField)])
@@ -42,7 +57,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
 
     @IBAction func submitTapped(sender: AnyObject) {
         println("Validating...")
-        self.clearErrors()
+//        self.clearErrors()
         validator.validate(self)
     }
 
@@ -58,38 +73,38 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
     }
     func validationFailed(errors:[UITextField:ValidationError]) {
         println("Validation FAILED!")
-        self.setErrors()
+//        self.setErrors()
     }
     
     // MARK: Error Styling
     
-    func removeError(label:UILabel, textField:UITextField) {
-        label.hidden = true
-        textField.layer.borderWidth = 0.0
-    }
+//    func removeError(label:UILabel, textField:UITextField) {
+//        label.hidden = true
+//        textField.layer.borderWidth = 0.0
+//    }
     
-    func removeAllErrors(){
-        removeError(fullNameErrorLabel, textField: fullNameTextField)
-        removeError(emailErrorLabel, textField: emailTextField)
-        removeError(phoneNumberErrorLabel, textField: phoneNumberTextField)
-        removeError(zipcodeErrorLabel, textField: zipcodeTextField)
-    }
+//    func removeAllErrors(){
+//        removeError(fullNameErrorLabel, textField: fullNameTextField)
+//        removeError(emailErrorLabel, textField: emailTextField)
+//        removeError(phoneNumberErrorLabel, textField: phoneNumberTextField)
+//        removeError(zipcodeErrorLabel, textField: zipcodeTextField)
+//    }
     
-    private func setErrors(){
-        for (field, error) in validator.errors {
-            field.layer.borderColor = UIColor.redColor().CGColor
-            field.layer.borderWidth = 1.0
-            error.errorLabel?.text = error.errorMessage
-            error.errorLabel?.hidden = false
-        }
-    }
+//    private func setErrors(){
+//        for (field, error) in validator.errors {
+//            field.layer.borderColor = UIColor.redColor().CGColor
+//            field.layer.borderWidth = 1.0
+//            error.errorLabel?.text = error.errorMessage
+//            error.errorLabel?.hidden = false
+//        }
+//    }
     
-    private func clearErrors(){
-        for (field, error) in validator.errors {
-            field.layer.borderWidth = 0.0
-            error.errorLabel?.hidden = true
-        }
-    }
+//    private func clearErrors(){
+//        for (field, error) in validator.errors {
+//            field.layer.borderWidth = 0.0
+//            error.errorLabel?.hidden = true
+//        }
+//    }
     
     func hideKeyboard(){
         self.view.endEditing(true)

--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -38,7 +38,6 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
         validator.registerField(emailConfirmTextField, errorLabel: emailConfirmErrorLabel, rules: [RequiredRule(), ConfirmationRule(confirmField: emailTextField)])
         validator.registerField(phoneNumberTextField, errorLabel: phoneNumberErrorLabel, rules: [RequiredRule(), MinLengthRule(length: 9)])
         validator.registerField(zipcodeTextField, errorLabel: zipcodeErrorLabel, rules: [RequiredRule(), ZipCodeRule()])
-        
     }
 
     @IBAction func submitTapped(sender: AnyObject) {

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -27,6 +27,9 @@ class ValidatorTests: XCTestCase {
     let VALID_PASSWORD = "Super$ecret"
     let INVALID_PASSWORD = "abc"
     
+    let VALID_FLOAT = "1234.444"
+    let INVALID_FLOAT = "1234.44.44"
+    
     let LEN_3 = "hey"
     let LEN_5 = "Howdy"
     let LEN_20 = "Paint the cat orange"
@@ -92,6 +95,17 @@ class ValidatorTests: XCTestCase {
     
     func testEmailInvalid() {
         XCTAssertFalse(EmailRule().validate(INVALID_EMAIL), "Email should be invalid")
+    }
+    
+    // MARK: Float
+    
+    func testFloat() {
+        XCTAssert(FloatRule().validate(VALID_FLOAT), "Float should be valid")
+    }
+    
+    func testFloatInvalid() {
+        XCTAssert(!FloatRule().validate(INVALID_FLOAT), "Float should be invalid")
+        XCTAssert(!FloatRule().validate(VALID_EMAIL), "Float should be invalid")
     }
     
     // MARK: Confirm against field

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -44,8 +44,6 @@ class ValidatorTests: XCTestCase {
     
     let ERROR_LABEL = UILabel()
     
-    let GREEN_COLOR = UIColor.greenColor()
-    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -44,6 +44,8 @@ class ValidatorTests: XCTestCase {
     
     let ERROR_LABEL = UILabel()
     
+    let GREEN_COLOR = UIColor.greenColor()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -236,6 +238,16 @@ class ValidatorTests: XCTestCase {
             }else{
                 XCTAssert(false, "Error label should have text, not nil")
             }
+        }
+    }
+    
+    func testTextFieldBorderColorSet() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
         }
     }
 }

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -44,6 +44,8 @@ class ValidatorTests: XCTestCase {
     
     let ERROR_LABEL = UILabel()
     
+    let GREEN_COLOR = UIColor.greenColor()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -236,6 +238,17 @@ class ValidatorTests: XCTestCase {
             }else{
                 XCTAssert(false, "Error label should have text, not nil")
             }
+        }
+    }
+    
+    func testTextFieldBorderColorSet() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+        REGISTER_VALIDATOR.textFieldErrorColor = GREEN_COLOR
+        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, self.GREEN_COLOR.CGColor), "Color should be what it was set as")
         }
     }
 }

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -42,6 +42,8 @@ class ValidatorTests: XCTestCase {
     let UNREGISTER_ERRORS_TXT_FIELD = UITextField()
     let UNREGISTER_ERRORS_VALIDATOR = Validator()
     
+    let ERROR_LABEL = UILabel()
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -191,6 +193,49 @@ class ValidatorTests: XCTestCase {
         REGISTER_TXT_FIELD.text = INVALID_EMAIL
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 1, "Should come back with 1 error")
+        }
+    }
+    
+    // MARK: Validate error field gets it's text set to the error, if supplied
+    
+    func testNoErrorMessageSet() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = VALID_EMAIL
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 0, "Should not come back with errors")
+            XCTAssert(self.ERROR_LABEL.text == nil, "Shouldn't have an error message on the label")
+        }
+    }
+    
+    func testErrorMessageSet() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+            if let errorText = self.ERROR_LABEL.text {
+                XCTAssert(errorText == errors[self.REGISTER_TXT_FIELD]!.errorMessage, "Shouldn't have an error message on the label, got: \(self.ERROR_LABEL.text!), expected: \(errors[self.REGISTER_TXT_FIELD]!.errorMessage)")
+            }else{
+                XCTAssert(false, "Error label should have text, not nil")
+            }
+        }
+    }
+    
+    func testErrorMessageSetAndThenUnset() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+            if let errorText = self.ERROR_LABEL.text {
+                XCTAssert(errorText == errors[self.REGISTER_TXT_FIELD]!.errorMessage, "Shouldn't have an error message on the label, got: \(self.ERROR_LABEL.text!), expected: \(errors[self.REGISTER_TXT_FIELD]!.errorMessage)")
+                
+                self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
+                self.REGISTER_VALIDATOR.validate { (errors) -> Void in
+                    XCTAssert(errors.count == 0, "Should not come back with errors")
+                    XCTAssert(self.ERROR_LABEL.text == nil, "Shouldn't have an error message on the label")
+                }
+            }else{
+                XCTAssert(false, "Error label should have text, not nil")
+            }
         }
     }
 }

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -44,8 +44,6 @@ class ValidatorTests: XCTestCase {
     
     let ERROR_LABEL = UILabel()
     
-    let GREEN_COLOR = UIColor.greenColor()
-    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -248,6 +246,15 @@ class ValidatorTests: XCTestCase {
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 1, "Should come back with errors")
             XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
+        }
+    }
+    
+    func testTextFieldBorderColorNotSet() {
+        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+        REGISTER_VALIDATOR.validate { (errors) -> Void in
+            XCTAssert(errors.count == 1, "Should come back with errors")
+            XCTAssert(!CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color shouldn't get set at all")
         }
     }
 }

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -260,6 +260,12 @@ class ValidatorTests: XCTestCase {
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 1, "Should come back with errors")
             XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
+            
+            self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
+            self.REGISTER_VALIDATOR.validate { (errors) -> Void in
+                XCTAssert(errors.count == 0, "Should come back without errors")
+                XCTAssert(!CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
+            }
         }
     }
     

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -217,57 +217,50 @@ class ValidatorTests: XCTestCase {
         REGISTER_TXT_FIELD.text = VALID_EMAIL
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 0, "Should not come back with errors")
-            XCTAssert(self.ERROR_LABEL.text == nil, "Shouldn't have an error message on the label")
         }
     }
     
     func testErrorMessageSet() {
         REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        var successCount = 0
+        var errorCount = 0
+        REGISTER_VALIDATOR.styleTransformers(success: { (validationRule) -> Void in
+            successCount++
+        }) { (validationError) -> Void in
+            errorCount++
+        }
         REGISTER_TXT_FIELD.text = INVALID_EMAIL
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 1, "Should come back with errors")
-            if let errorText = self.ERROR_LABEL.text {
-                XCTAssert(errorText == errors[self.REGISTER_TXT_FIELD]!.errorMessage, "Shouldn't have an error message on the label, got: \(self.ERROR_LABEL.text!), expected: \(errors[self.REGISTER_TXT_FIELD]!.errorMessage)")
-            }else{
-                XCTAssert(false, "Error label should have text, not nil")
-            }
+            XCTAssert(errorCount == 1, "Should have called the error style transform once")
+            XCTAssert(successCount == 0, "Should not have called the success style transform as there are no successful fields")
         }
     }
     
     func testErrorMessageSetAndThenUnset() {
         REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+        
+        var successCount = 0
+        var errorCount = 0
+        REGISTER_VALIDATOR.styleTransformers(success: { (validationRule) -> Void in
+            successCount++
+            }) { (validationError) -> Void in
+                errorCount++
+        }
+        
         REGISTER_TXT_FIELD.text = INVALID_EMAIL
         REGISTER_VALIDATOR.validate { (errors) -> Void in
             XCTAssert(errors.count == 1, "Should come back with errors")
-            if let errorText = self.ERROR_LABEL.text {
-                XCTAssert(errorText == errors[self.REGISTER_TXT_FIELD]!.errorMessage, "Shouldn't have an error message on the label, got: \(self.ERROR_LABEL.text!), expected: \(errors[self.REGISTER_TXT_FIELD]!.errorMessage)")
-                
-                self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
-                self.REGISTER_VALIDATOR.validate { (errors) -> Void in
-                    XCTAssert(errors.count == 0, "Should not come back with errors")
-                    XCTAssert(self.ERROR_LABEL.text == nil, "Shouldn't have an error message on the label")
-                }
-            }else{
-                XCTAssert(false, "Error label should have text, not nil")
+            XCTAssert(errorCount == 1, "Should have called the error style transform once")
+            XCTAssert(successCount == 0, "Should not have called the success style transform as there are no successful fields")
+            self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
+            self.REGISTER_VALIDATOR.validate { (errors) -> Void in
+                XCTAssert(errors.count == 0, "Should not come back with errors: \(errors)")
+                XCTAssert(successCount == 1, "Should have called the success style transform once")
+                XCTAssert(errorCount == 1, "Should not have called the error style transform again")
             }
         }
     }
-    
-//    func testTextFieldBorderColorSet() {
-//        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
-//        REGISTER_TXT_FIELD.text = INVALID_EMAIL
-//        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
-//        REGISTER_VALIDATOR.validate { (errors) -> Void in
-//            XCTAssert(errors.count == 1, "Should come back with errors")
-//            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
-//            
-//            self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
-//            self.REGISTER_VALIDATOR.validate { (errors) -> Void in
-//                XCTAssert(errors.count == 0, "Should come back without errors")
-//                XCTAssert(!CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
-//            }
-//        }
-//    }
     
     func testTextFieldBorderColorNotSet() {
         REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -240,15 +240,4 @@ class ValidatorTests: XCTestCase {
             }
         }
     }
-    
-    func testTextFieldBorderColorSet() {
-        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
-        REGISTER_TXT_FIELD.text = INVALID_EMAIL
-        REGISTER_VALIDATOR.textFieldErrorColor = GREEN_COLOR
-        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
-        REGISTER_VALIDATOR.validate { (errors) -> Void in
-            XCTAssert(errors.count == 1, "Should come back with errors")
-            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, self.GREEN_COLOR.CGColor), "Color should be what it was set as")
-        }
-    }
 }

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -253,21 +253,21 @@ class ValidatorTests: XCTestCase {
         }
     }
     
-    func testTextFieldBorderColorSet() {
-        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
-        REGISTER_TXT_FIELD.text = INVALID_EMAIL
-        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
-        REGISTER_VALIDATOR.validate { (errors) -> Void in
-            XCTAssert(errors.count == 1, "Should come back with errors")
-            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
-            
-            self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
-            self.REGISTER_VALIDATOR.validate { (errors) -> Void in
-                XCTAssert(errors.count == 0, "Should come back without errors")
-                XCTAssert(!CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
-            }
-        }
-    }
+//    func testTextFieldBorderColorSet() {
+//        REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])
+//        REGISTER_TXT_FIELD.text = INVALID_EMAIL
+//        REGISTER_VALIDATOR.shouldMarkTextFieldsInError = true
+//        REGISTER_VALIDATOR.validate { (errors) -> Void in
+//            XCTAssert(errors.count == 1, "Should come back with errors")
+//            XCTAssert(CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
+//            
+//            self.REGISTER_TXT_FIELD.text = self.VALID_EMAIL
+//            self.REGISTER_VALIDATOR.validate { (errors) -> Void in
+//                XCTAssert(errors.count == 0, "Should come back without errors")
+//                XCTAssert(!CGColorEqualToColor(self.REGISTER_TXT_FIELD.layer.borderColor, UIColor.redColor().CGColor), "Color should be what it was set as")
+//            }
+//        }
+//    }
     
     func testTextFieldBorderColorNotSet() {
         REGISTER_VALIDATOR.registerField(REGISTER_TXT_FIELD, errorLabel: ERROR_LABEL, rules: [EmailRule()])


### PR DESCRIPTION
Error labels can be set automatically, FloatRule

A string can now be checked to see if it is a float.
If supplied, the error label of a field gets set with the error string automatically.
If shouldMarkTextFieldsInError is set(default false) the text field's border gets set to red and unset every time validate is run.