### PR TITLE
Using array of tuples instead of Dictionary for errors and validators.

### DIFF
--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 
-class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate {
+class ViewController: UIViewController, ValidationDelegate, UITextFieldDelegate {
 
     // TextFields
     @IBOutlet weak var fullNameTextField: UITextField!
@@ -71,7 +71,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
         self.presentViewController(alert, animated: true, completion: nil)
     
     }
-    func validationFailed(errors:[UITextField:ValidationError]) {
+    func validationFailed(errors:ValidatorErrors) {
         println("Validation FAILED!")
     }
     


### PR DESCRIPTION
For example in my project I need to get correctly ordered errors. if my first textField failed, I can scroll to that text field easily by getting `first` element from array or I can show onscreen error easily.

Also possible solution is to use custom struct (Ordered dictionary): http://timekl.com/blog/2014/06/02/learning-swift-ordered-dictionaries/

What do you think?
