### PR TITLE
Migrate to Swift 2.0

### DIFF
--- a/SwiftValidator.podspec
+++ b/SwiftValidator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftValidator"
-  s.version      = "2.1.1"
+  s.version      = "3.0.0"
   s.summary      = "A UITextField Validation library for Swift"
   s.homepage     = "https://github.com/jpotts18/SwiftValidator"
   s.screenshots  = "https://raw.githubusercontent.com/jpotts18/SwiftValidator/master/swift-validator-v2.gif"
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/jpotts18"
   s.platform     = :ios
   s.ios.deployment_target	= '8.0'
-  s.source       = { :git => "https://github.com/jpotts18/SwiftValidator.git", :tag => "2.1.1" }
+  s.source       = { :git => "https://github.com/jpotts18/SwiftValidator.git", :tag => "3.0.0" }
   s.source_files  = "Validator/*.swift"
   s.frameworks   = ['Foundation', 'UIKit']
   s.requires_arc = true

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		62DC8D6E1AAA42CE0095DFA7 /* PasswordRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DC8D6B1AAA42CE0095DFA7 /* PasswordRule.swift */; };
 		62DC8D711AAA43110095DFA7 /* ZipCodeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */; };
 		62E9E2AD1ACFB336000A939C /* RegexRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9E2AC1ACFB336000A939C /* RegexRule.swift */; };
+		D7C1D97E1BA25940008CE686 /* PhoneNumberRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C1D97D1BA25940008CE686 /* PhoneNumberRule.swift */; settings = {ASSET_TAGS = (); }; };
 		DC5A35EC1AF99BA60013FE6B /* FloatRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,7 @@
 		62DC8D6B1AAA42CE0095DFA7 /* PasswordRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordRule.swift; sourceTree = "<group>"; };
 		62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipCodeRule.swift; sourceTree = "<group>"; };
 		62E9E2AC1ACFB336000A939C /* RegexRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexRule.swift; sourceTree = "<group>"; };
+		D7C1D97D1BA25940008CE686 /* PhoneNumberRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberRule.swift; sourceTree = "<group>"; };
 		DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -163,17 +165,18 @@
 		62DC8D661AAA42700095DFA7 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
+				628637271AAA49E300BC8FCF /* ConfirmRule.swift */,
+				62DC8D691AAA42CE0095DFA7 /* EmailRule.swift */,
+				DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */,
+				62DC8D671AAA42920095DFA7 /* FullNameRule.swift */,
 				623F29931AD836E6005B26CB /* MaxLengthRule.swift */,
 				628637251AAA474B00BC8FCF /* MinLengthRule.swift */,
-				62DC8D641AAA42520095DFA7 /* Rule.swift */,
-				62DC8D691AAA42CE0095DFA7 /* EmailRule.swift */,
-				62DC8D6A1AAA42CE0095DFA7 /* RequiredRule.swift */,
 				62DC8D6B1AAA42CE0095DFA7 /* PasswordRule.swift */,
-				62DC8D671AAA42920095DFA7 /* FullNameRule.swift */,
-				62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */,
-				628637271AAA49E300BC8FCF /* ConfirmRule.swift */,
+				D7C1D97D1BA25940008CE686 /* PhoneNumberRule.swift */,
 				62E9E2AC1ACFB336000A939C /* RegexRule.swift */,
-				DC5A35EB1AF99BA60013FE6B /* FloatRule.swift */,
+				62DC8D6A1AAA42CE0095DFA7 /* RequiredRule.swift */,
+				62DC8D641AAA42520095DFA7 /* Rule.swift */,
+				62DC8D701AAA43110095DFA7 /* ZipCodeRule.swift */,
 			);
 			name = Rules;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				62D1AE4F1A1E6FF800E4DFF8 /* ValidationError.swift in Sources */,
 				62DC8D6E1AAA42CE0095DFA7 /* PasswordRule.swift in Sources */,
 				62DC8D6C1AAA42CE0095DFA7 /* EmailRule.swift in Sources */,
+				D7C1D97E1BA25940008CE686 /* PhoneNumberRule.swift in Sources */,
 				628637281AAA49E300BC8FCF /* ConfirmRule.swift in Sources */,
 				62DC8D651AAA42520095DFA7 /* Rule.swift in Sources */,
 				62D1AE1F1A1E6D4400E4DFF8 /* ViewController.swift in Sources */,

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = jpotts18;
 				TargetAttributes = {
 					62D1AE161A1E6D4400E4DFF8 = {
@@ -356,6 +356,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -419,6 +420,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Validator/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -429,6 +431,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Validator/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -447,6 +450,7 @@
 				);
 				INFOPLIST_FILE = ValidatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Validator.app/Validator";
 			};
@@ -462,6 +466,7 @@
 				);
 				INFOPLIST_FILE = ValidatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Validator.app/Validator";
 			};

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		62D1AE0F1A1E6D4400E4DFF8 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = jpotts18;
 				TargetAttributes = {

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -440,10 +440,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -460,10 +456,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = ValidatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Validator/FloatRule.swift
+++ b/Validator/FloatRule.swift
@@ -17,9 +17,9 @@ public class FloatRule:Rule {
     }
     
     public func validate(value: String) -> Bool {
-        let regex = NSRegularExpression(pattern: "[-+]?(\\d*[.])?\\d+", options: nil, error: nil)
+        let regex = try? NSRegularExpression(pattern: "[-+]?(\\d*[.])?\\d+", options: [])
         if let regex = regex {
-            let match = regex.numberOfMatchesInString(value, options: nil, range: NSRange(location: 0, length: count(value)))
+            let match = regex.numberOfMatchesInString(value, options: [], range: NSRange(location: 0, length: value.characters.count))
             return match == 1
         }
         return false

--- a/Validator/FullNameRule.swift
+++ b/Validator/FullNameRule.swift
@@ -18,7 +18,7 @@ public class FullNameRule : Rule {
     }
         
     public func validate(value: String) -> Bool {
-        var nameArray: [String] = split(value) { $0 == " " }
+        let nameArray: [String] = value.characters.split { $0 == " " }.map { String($0) }
         return nameArray.count >= 2
     }
     

--- a/Validator/Info.plist
+++ b/Validator/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Validator/MaxLengthRule.swift
+++ b/Validator/MaxLengthRule.swift
@@ -20,7 +20,7 @@ public class MaxLengthRule: Rule {
     }
         
     public func validate(value: String) -> Bool {
-        return count(value) <= DEFAULT_LENGTH
+        return value.characters.count <= DEFAULT_LENGTH
     }
     
     public func errorMessage() -> String {

--- a/Validator/MinLengthRule.swift
+++ b/Validator/MinLengthRule.swift
@@ -21,7 +21,7 @@ public class MinLengthRule: Rule {
     }
     
     public func validate(value: String) -> Bool {
-        return count(value) >= DEFAULT_LENGTH
+        return value.characters.count >= DEFAULT_LENGTH
     }
     
     public func errorMessage() -> String {

--- a/Validator/PhoneNumberRule.swift
+++ b/Validator/PhoneNumberRule.swift
@@ -17,7 +17,7 @@ class PhoneNumberRule: Rule {
     }
     
     func validate(value: String) -> Bool {
-        var phoneTest = NSPredicate(format: "SELF MATCHES %@", PHONE_REGEX)
+        let phoneTest = NSPredicate(format: "SELF MATCHES %@", PHONE_REGEX)
         return phoneTest.evaluateWithObject(value)
     }
     

--- a/Validator/ValidationError.swift
+++ b/Validator/ValidationError.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public class ValidationError {
+public class ValidationError: NSObject {
     public let textField:UITextField
     public var errorLabel:UILabel?
     public let errorMessage:String

--- a/Validator/ValidationRule.swift
+++ b/Validator/ValidationRule.swift
@@ -21,7 +21,7 @@ public class ValidationRule {
     }
     
     public func validateField() -> ValidationError? {
-        return rules.filter{ !$0.validate(self.textField.text) }
+        return rules.filter{ !$0.validate(self.textField.text ?? "") }
                     .map{ rule -> ValidationError in return ValidationError(textField: self.textField, errorLabel:self.errorLabel, error: rule.errorMessage()) }.first
     }
 }

--- a/Validator/Validator.swift
+++ b/Validator/Validator.swift
@@ -30,7 +30,7 @@ public class Validator {
         errors = [:]
         
         for (textField, rule) in validations {
-            if var error = rule.validateField() {
+            if let error = rule.validateField() {
                 errors[textField] = error
                 
                 // let the user transform the field if they want
@@ -49,7 +49,7 @@ public class Validator {
     
     // MARK: Using Keys
     
-    public func styleTransformers(#success:((validationRule:ValidationRule)->Void)?, error:((validationError:ValidationError)->Void)?) {
+    public func styleTransformers(success success:((validationRule:ValidationRule)->Void)?, error:((validationError:ValidationError)->Void)?) {
         self.successStyleTransform = success
         self.errorStyleTransform = error
     }

--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: "hideKeyboard"))
         
         validator.styleTransformers(success:{ (validationRule) -> Void in
-            println("here")
+            print("here")
                 // clear error label
                 validationRule.errorLabel?.hidden = true
                 validationRule.errorLabel?.text = ""
@@ -42,7 +42,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
                 validationRule.textField.layer.borderWidth = 0.5
             
             }, error:{ (validationError) -> Void in
-                println("error")
+                print("error")
                 validationError.errorLabel?.hidden = false
                 validationError.errorLabel?.text = validationError.errorMessage
                 validationError.textField.layer.borderColor = UIColor.redColor().CGColor
@@ -57,22 +57,22 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
     }
 
     @IBAction func submitTapped(sender: AnyObject) {
-        println("Validating...")
+        print("Validating...")
         validator.validate(self)
     }
 
     // MARK: ValidationDelegate Methods
     
     func validationSuccessful() {
-        println("Validation Success!")
-        var alert = UIAlertController(title: "Success", message: "You are validated!", preferredStyle: UIAlertControllerStyle.Alert)
-        var defaultAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
+        print("Validation Success!")
+        let alert = UIAlertController(title: "Success", message: "You are validated!", preferredStyle: UIAlertControllerStyle.Alert)
+        let defaultAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
         alert.addAction(defaultAction)
         self.presentViewController(alert, animated: true, completion: nil)
     
     }
     func validationFailed(errors:[UITextField:ValidationError]) {
-        println("Validation FAILED!")
+        print("Validation FAILED!")
     }
     
     func hideKeyboard(){

--- a/ValidatorTests/Info.plist
+++ b/ValidatorTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>me.jeffpotter.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -35,15 +35,15 @@ class ValidatorTests: XCTestCase {
     let LEN_20 = "Paint the cat orange"
     
     let REGISTER_TXT_FIELD = UITextField()
-    let REGISTER_VALIDATOR = Validator()
+    let REGISTER_VALIDATOR = Validator
     let REGISTER_RULES = [Rule]()
     
     let UNREGISTER_TXT_FIELD = UITextField()
-    let UNREGISTER_VALIDATOR = Validator()
+    let UNREGISTER_VALIDATOR = Validator
     let UNREGISTER_RULES = [Rule]()
     
     let UNREGISTER_ERRORS_TXT_FIELD = UITextField()
-    let UNREGISTER_ERRORS_VALIDATOR = Validator()
+    let UNREGISTER_ERRORS_VALIDATOR = Validator
     
     let ERROR_LABEL = UILabel()
     

--- a/ValidatorTests/ValidatorTests.swift
+++ b/ValidatorTests/ValidatorTests.swift
@@ -35,15 +35,15 @@ class ValidatorTests: XCTestCase {
     let LEN_20 = "Paint the cat orange"
     
     let REGISTER_TXT_FIELD = UITextField()
-    let REGISTER_VALIDATOR = Validator
+    let REGISTER_VALIDATOR = Validator()
     let REGISTER_RULES = [Rule]()
     
     let UNREGISTER_TXT_FIELD = UITextField()
-    let UNREGISTER_VALIDATOR = Validator
+    let UNREGISTER_VALIDATOR = Validator()
     let UNREGISTER_RULES = [Rule]()
     
     let UNREGISTER_ERRORS_TXT_FIELD = UITextField()
-    let UNREGISTER_ERRORS_VALIDATOR = Validator
+    let UNREGISTER_ERRORS_VALIDATOR = Validator()
     
     let ERROR_LABEL = UILabel()
     


### PR DESCRIPTION
Another option to close issue #37.

I pulled master and ran through the Swift 2.0 migration using the Xcode 7 GM release. In this branch you should still see a full suite of passing tests, 0 warnings when build with the GM, and a version bump to 3.0.0 to account for the backwards incompatible change to Swift 2.0.

I'd like to exercise this more completely but I still have some other 2.0 migration issues to fix before I can see it in action in my current app. All I can be completely confident of at the moment is that installation (via `pod 'SwiftValidator', git: 'https://github.com/goodeggs/SwiftValidator.git', branch: 'swift-2.0'`) gives my app a Pods sub project which builds cleanly.