### PR TITLE
Added the AppDelegate as an exclude-pod-file

### DIFF
--- a/SwiftValidator.podspec
+++ b/SwiftValidator.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target	= '8.0'
   s.source       = { :git => "https://github.com/jpotts18/SwiftValidator.git", :tag => "3.0.0" }
   s.source_files  = "Validator/*.swift"
+  s.exclude_files = "Validator/AppDelegate.swift"
   s.frameworks   = ['Foundation', 'UIKit']
   s.requires_arc = true
 end


### PR DESCRIPTION
I just removed the AppDelegate from being included with the pod.  This causes compilation errors.

This fix also addresses the issue:
https://github.com/jpotts18/SwiftValidator/issues/50