### PR TITLE
text in UITextField can be prepared based on preparators before validation

### DIFF
--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -55,11 +55,23 @@ public class Validator {
     }
     
     public func registerField(textField:UITextField, rules:[Rule]) {
-        validations[textField] = ValidationRule(textField: textField, rules: rules, errorLabel: nil)
+        registerFieldInternally(textField, errorLabel: nil, preparators: nil, rules: rules)
     }
     
     public func registerField(textField:UITextField, errorLabel:UILabel, rules:[Rule]) {
-        validations[textField] = ValidationRule(textField: textField, rules:rules, errorLabel:errorLabel)
+        registerFieldInternally(textField, errorLabel: errorLabel, preparators: nil, rules: rules)
+    }
+    
+    public func registerField(textField:UITextField, preparators: [Preparator], rules:[Rule]) {
+        registerFieldInternally(textField, errorLabel: nil, preparators: preparators, rules: rules)
+    }
+    
+    public func registerField(textField:UITextField, errorLabel:UILabel, preparators: [Preparator], rules:[Rule]) {
+        registerFieldInternally(textField, errorLabel: errorLabel, preparators: preparators, rules: rules)
+    }
+    
+    private func registerFieldInternally(textField: UITextField, errorLabel: UILabel?, preparators: [Preparator]?, rules: [Rule]) {
+        validations[textField] = ValidationRule(textField: textField, preparators: preparators, rules: rules, errorLabel: errorLabel)
     }
     
     public func unregisterField(textField:UITextField) {

--- a/SwiftValidator/Preparators/Preparator.swift
+++ b/SwiftValidator/Preparators/Preparator.swift
@@ -1,0 +1,14 @@
+//
+//  Preparator.swift
+//  Validator
+//
+//  Created by Łukasz Osiennik on 30/10/15.
+//  Copyright (c) 2015 jpotts18. All rights reserved.
+//
+
+import Foundation
+
+public protocol Preparator {
+    
+    func prepare(textField: UITextField) -> Bool
+}

--- a/SwiftValidator/Preparators/TrimSpacesPreparator.swift
+++ b/SwiftValidator/Preparators/TrimSpacesPreparator.swift
@@ -1,0 +1,27 @@
+//
+//  TrimSpacesPreparator.swift
+//  Validator
+//
+//  Created by Łukasz Osiennik on 30/10/15.
+//  Copyright (c) 2015 jpotts18. All rights reserved.
+//
+
+import Foundation
+
+public class TrimSpacesPreparator: Preparator {
+    
+    public init() {
+        
+    }
+    
+    public func prepare(textField: UITextField) -> Bool {
+        
+        let previousText = textField.text ?? ""
+        
+        let currentText = previousText.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+        
+        textField.text = currentText
+        
+        return currentText != previousText;
+    }
+}

--- a/SwiftValidator/Rules/ValidationRule.swift
+++ b/SwiftValidator/Rules/ValidationRule.swift
@@ -12,16 +12,26 @@ import UIKit
 public class ValidationRule {
     public var textField:UITextField
     public var errorLabel:UILabel?
+    public var preparators:[Preparator]?
     public var rules:[Rule] = []
     
-    public init(textField: UITextField, rules:[Rule], errorLabel:UILabel?){
+    public init(textField: UITextField, preparators: [Preparator]?, rules: [Rule], errorLabel: UILabel?) {
         self.textField = textField
         self.errorLabel = errorLabel
+        self.preparators = preparators
         self.rules = rules
     }
     
     public func validateField() -> ValidationError? {
+        
+        if let preparators = preparators {
+            
+            for preparator in preparators {
+                preparator.prepare(textField)
+            }
+        }
+        
         return rules.filter{ !$0.validate(self.textField.text ?? "") }
-                    .map{ rule -> ValidationError in return ValidationError(textField: self.textField, errorLabel:self.errorLabel, error: rule.errorMessage()) }.first
+            .map{ rule -> ValidationError in return ValidationError(textField: self.textField, errorLabel:self.errorLabel, error: rule.errorMessage()) }.first
     }
 }

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		62D1AE221A1E6D4400E4DFF8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 62D1AE201A1E6D4400E4DFF8 /* Main.storyboard */; };
 		62D1AE241A1E6D4400E4DFF8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 62D1AE231A1E6D4400E4DFF8 /* Images.xcassets */; };
 		62D1AE271A1E6D4400E4DFF8 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 62D1AE251A1E6D4400E4DFF8 /* LaunchScreen.xib */; };
+		D55702821BE375D6008D0ABB /* Preparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55702811BE375D6008D0ABB /* Preparator.swift */; };
+		D55702841BE375F6008D0ABB /* TrimSpacesPreparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55702831BE375F6008D0ABB /* TrimSpacesPreparator.swift */; };
 		FB465CB81B9884F400398388 /* SwiftValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = FB465CB71B9884F400398388 /* SwiftValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FB465CBE1B9884F400398388 /* SwiftValidator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB465CB31B9884F400398388 /* SwiftValidator.framework */; };
 		FB465CC71B9884F400398388 /* SwiftValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB465CC61B9884F400398388 /* SwiftValidatorTests.swift */; };
@@ -89,6 +91,8 @@
 		62D1AE261A1E6D4400E4DFF8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		62D1AE2C1A1E6D4500E4DFF8 /* ValidatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ValidatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		62D1AE311A1E6D4500E4DFF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D55702811BE375D6008D0ABB /* Preparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Preparator.swift; path = Preparators/Preparator.swift; sourceTree = "<group>"; };
+		D55702831BE375F6008D0ABB /* TrimSpacesPreparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TrimSpacesPreparator.swift; path = Preparators/TrimSpacesPreparator.swift; sourceTree = "<group>"; };
 		FB465CB31B9884F400398388 /* SwiftValidator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftValidator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB465CB61B9884F400398388 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FB465CB71B9884F400398388 /* SwiftValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftValidator.h; sourceTree = "<group>"; };
@@ -205,9 +209,19 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		D55702801BE3759A008D0ABB /* Preparators */ = {
+			isa = PBXGroup;
+			children = (
+				D55702811BE375D6008D0ABB /* Preparator.swift */,
+				D55702831BE375F6008D0ABB /* TrimSpacesPreparator.swift */,
+			);
+			name = Preparators;
+			sourceTree = "<group>";
+		};
 		FB465CB41B9884F400398388 /* SwiftValidator */ = {
 			isa = PBXGroup;
 			children = (
+				D55702801BE3759A008D0ABB /* Preparators */,
 				FB465CE21B9889EA00398388 /* Rules */,
 				FB465CF01B9889EA00398388 /* Core */,
 				FB465CB71B9884F400398388 /* SwiftValidator.h */,
@@ -472,10 +486,12 @@
 				FB465CFE1B9889EA00398388 /* ValidationRule.swift in Sources */,
 				FB465CF31B9889EA00398388 /* ConfirmRule.swift in Sources */,
 				FB465D001B9889EA00398388 /* ValidationError.swift in Sources */,
+				D55702821BE375D6008D0ABB /* Preparator.swift in Sources */,
 				FB465CFC1B9889EA00398388 /* RequiredRule.swift in Sources */,
 				FB465CFB1B9889EA00398388 /* RegexRule.swift in Sources */,
 				FB465CF81B9889EA00398388 /* MinLengthRule.swift in Sources */,
 				FB465CF71B9889EA00398388 /* MaxLengthRule.swift in Sources */,
+				D55702841BE375F6008D0ABB /* TrimSpacesPreparator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Preparator Feature, it could be useful I think. How it works? Before validation of UITextField, text could be additionally prepared, e.g. text trimming could be performed (preparator implemented in this PR), any prefix text could be added before original text, some chars could be removed from the original text, and so on. I hope you will find that useful.