### PR TITLE
Return successfully validated text fields as delegate parameter

### DIFF
--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -10,13 +10,14 @@ import Foundation
 import UIKit
 
 @objc public protocol ValidationDelegate {
-    func validationSuccessful()
+    func validationSuccessful(validFields: [UITextField])
     func validationFailed(errors: [UITextField:ValidationError])
 }
 
 public class Validator {
     // dictionary to handle complex view hierarchies like dynamic tableview cells
     public var errors = [UITextField:ValidationError]()
+    public var validFields = [UITextField]()
     public var validations = [UITextField:ValidationRule]()
     private var successStyleTransform:((validationRule:ValidationRule)->Void)?
     private var errorStyleTransform:((validationError:ValidationError)->Void)?
@@ -28,6 +29,7 @@ public class Validator {
     private func validateAllFields() {
         
         errors = [:]
+        validFields = []
         
         for (textField, rule) in validations {
             if let error = rule.validateField() {
@@ -39,6 +41,8 @@ public class Validator {
                 }
             } else {
                 // No error
+                validFields.append(textField)
+                
                 // let the user transform the field if they want
                 if let transform = self.successStyleTransform {
                     transform(validationRule: rule)
@@ -72,7 +76,7 @@ public class Validator {
         self.validateAllFields()
         
         if errors.isEmpty {
-            delegate.validationSuccessful()
+            delegate.validationSuccessful(validFields)
         } else {
             delegate.validationFailed(errors)
         }

--- a/Validator/ViewController.swift
+++ b/Validator/ViewController.swift
@@ -63,7 +63,7 @@ class ViewController: UIViewController , ValidationDelegate, UITextFieldDelegate
 
     // MARK: ValidationDelegate Methods
     
-    func validationSuccessful() {
+    func validationSuccessful(validFields: [UITextField]) {
         print("Validation Success!")
         let alert = UIAlertController(title: "Success", message: "You are validated!", preferredStyle: UIAlertControllerStyle.Alert)
         let defaultAction = UIAlertAction(title: "OK", style: .Default, handler: nil)


### PR DESCRIPTION
Updated the ValidationDelegate and Validator to return the successfully validated text fields. This is useful if you want to reset the text field styling once a user corrected a field.