### PR TITLE
Remove duplicate functions by using default values

### DIFF
--- a/SwiftValidator/Core/ValidationError.swift
+++ b/SwiftValidator/Core/ValidationError.swift
@@ -18,18 +18,6 @@ public class ValidationError: NSObject {
     public let errorMessage:String
     
     /**
-     Initializes `ValidationError` object with a textField and error.
-     
-     - parameter textField: UITextField that holds textField.
-     - parameter errorMessage: String that holds error message.
-     - returns: An initialized object, or nil if an object could not be created for some reason that would not result in an exception.
-     */
-    public init(textField:UITextField, error:String){
-        self.textField = textField
-        self.errorMessage = error
-    }
-    
-    /**
      Initializes `ValidationError` object with a textField, errorLabel, and errorMessage.
      
      - parameter textField: UITextField that holds textField.

--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -99,23 +99,12 @@ public class Validator {
     /**
      This method is used to add a field to validator.
      
-     - parameter textField: field that is to be validated.
-     - parameter Rule: An array which holds different rules to validate against textField.
-     - returns: No return value
-     */
-    public func registerField(textField:UITextField, rules:[Rule]) {
-        validations[textField] = ValidationRule(textField: textField, rules: rules, errorLabel: nil)
-    }
-    
-    /**
-     This method is used to add a field to validator.
-     
      - parameter textfield: field that is to be validated.
      - parameter errorLabel: A UILabel that holds error label data
      - parameter rules: A Rule array that holds different rules that apply to said textField.
      - returns: No return value
      */
-    public func registerField(textField:UITextField, errorLabel:UILabel, rules:[Rule]) {
+    public func registerField(textField:UITextField, errorLabel:UILabel? = nil, rules:[Rule]) {
         validations[textField] = ValidationRule(textField: textField, rules:rules, errorLabel:errorLabel)
     }
     


### PR DESCRIPTION
Remove duplicate (unnecessary) functions by using default values for optional parameters