### PR TITLE
fix #115: support for longer domain names from ICANN

### DIFF
--- a/SwiftValidator/Rules/EmailRule.swift
+++ b/SwiftValidator/Rules/EmailRule.swift
@@ -13,7 +13,7 @@ import Foundation
 public class EmailRule: RegexRule {
     
     /// Regular express string to be used in validation.
-    static let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
+    static let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
     
     /**
      Initializes an `EmailRule` object to validate an email text field.


### PR DESCRIPTION
Removes the limitation of 6 character to the domain, as it is not in ICANN anymore.

I still would like to know why there is the need to double escape the . in

    \\.
 
