### PR TITLE
Allow custom validation rule Swift 3 

### DIFF
--- a/SwiftValidator/Rules/RegexRule.swift
+++ b/SwiftValidator/Rules/RegexRule.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  `RegexRule` is a subclass of Rule that defines how a regular expression is validated.
  */
-public class RegexRule : Rule {
+open class RegexRule : Rule {
     /// Regular express string to be used in validation.
     private var REGEX: String = "^(?=.*?[A-Z]).{8,}$"
     /// String that holds error message.


### PR DESCRIPTION
Fix for #162 

I made the Regex rule open. Why? : 

> 
> Swift 3 is adding 2 more access levels (open and fileprivate) and changing the meaning of private:
> 
> private: symbol visible within the current declaration only.
> fileprivate: symbol visible within the current file.
> internal: symbol visible within the current module.
> public: symbol visible outside the current module.
> open: for class or function to be subclassed or overridden outside the current module.