### PR TITLE
Feature/removes validatable field typealias

### DIFF
--- a/SwiftValidator/Core/Validatable.swift
+++ b/SwiftValidator/Core/Validatable.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-public typealias ValidatableField = AnyObject & Validatable
-
-public protocol Validatable {
+public protocol Validatable: class {
     
     var validationText: String {
         get

--- a/SwiftValidator/Core/ValidationError.swift
+++ b/SwiftValidator/Core/ValidationError.swift
@@ -11,7 +11,7 @@ import UIKit
  */
 public class ValidationError: NSObject {
     /// the Validatable field of the field
-    public let field:ValidatableField
+    public let field:Validatable
     /// the error label of the field
     public var errorLabel:UILabel?
     /// the error message of the field
@@ -25,7 +25,7 @@ public class ValidationError: NSObject {
      - parameter errorMessage: String that holds error message.
      - returns: An initialized object, or nil if an object could not be created for some reason that would not result in an exception.
      */
-    public init(field:ValidatableField, errorLabel:UILabel?, error:String){
+    public init(field:Validatable, errorLabel:UILabel?, error:String){
         self.field = field
         self.errorLabel = errorLabel
         self.errorMessage = error

--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -12,7 +12,7 @@ import UIKit
  Class that makes `Validator` objects. Should be added as a parameter to ViewController that will display
  validation fields.
  */
-public class Validator {
+open class Validator {
     /// Dictionary to hold all fields (and accompanying rules) that will undergo validation.
     public var validations = ValidatorDictionary<ValidationRule>()
     /// Dictionary to hold fields (and accompanying errors) that were unsuccessfully validated.

--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -63,7 +63,7 @@ public class Validator {
     - parameter field: Holds validator field data.
     - returns: No return value.
     */
-    public func validateField(_ field: ValidatableField, callback: (_ error:ValidationError?) -> Void){
+    public func validateField(_ field: Validatable, callback: (_ error:ValidationError?) -> Void){
         if let fieldRule = validations[field] {
             if let error = fieldRule.validateField() {
                 errors[field] = error
@@ -104,7 +104,7 @@ public class Validator {
      - parameter rules: A Rule array that holds different rules that apply to said field.
      - returns: No return value
      */
-    public func registerField(_ field: ValidatableField, errorLabel:UILabel? = nil, rules:[Rule]) {
+    public func registerField(_ field: Validatable, errorLabel:UILabel? = nil, rules:[Rule]) {
         validations[field] = ValidationRule(field: field, rules:rules, errorLabel:errorLabel)
     }
     
@@ -114,7 +114,7 @@ public class Validator {
      - parameter field: field used to locate and remove field from validator.
      - returns: No return value
      */
-    public func unregisterField(_ field:ValidatableField) {
+    public func unregisterField(_ field:Validatable) {
         validations.removeValueForKey(field)
         errors.removeValueForKey(field)
     }

--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -17,8 +17,6 @@ public class Validator {
     public var validations = ValidatorDictionary<ValidationRule>()
     /// Dictionary to hold fields (and accompanying errors) that were unsuccessfully validated.
     public var errors = ValidatorDictionary<ValidationError>()
-    /// Dictionary to hold fields by their object identifiers
-    private var fields = ValidatorDictionary<Validatable>()
     /// Variable that holds success closure to display positive status of field.
     private var successStyleTransform:((_ validationRule:ValidationRule)->Void)?
     /// Variable that holds error closure to display negative status of field.
@@ -108,7 +106,6 @@ public class Validator {
      */
     public func registerField(_ field: ValidatableField, errorLabel:UILabel? = nil, rules:[Rule]) {
         validations[field] = ValidationRule(field: field, rules:rules, errorLabel:errorLabel)
-        fields[field] = field
     }
     
     /**
@@ -134,7 +131,7 @@ public class Validator {
         if errors.isEmpty {
             delegate.validationSuccessful()
         } else {
-            delegate.validationFailed(errors.map { (fields[$1.field]!, $1) })
+            delegate.validationFailed(errors.map { ($1.field, $1) })
         }
         
     }
@@ -149,6 +146,6 @@ public class Validator {
         
         self.validateAllFields()
         
-        callback(errors.map { (fields[$1.field]!, $1) } )
+        callback(errors.map { ($1.field, $1) } )
     }
 }

--- a/SwiftValidator/Core/ValidatorDictionary.swift
+++ b/SwiftValidator/Core/ValidatorDictionary.swift
@@ -12,7 +12,7 @@ public struct ValidatorDictionary<T> : Sequence {
     
     private var innerDictionary: [ObjectIdentifier: T] = [:];
     
-    public subscript(key: ValidatableField?) -> T? {
+    public subscript(key: Validatable?) -> T? {
         get {
             if let key = key {
                 return innerDictionary[ObjectIdentifier(key)];
@@ -31,7 +31,7 @@ public struct ValidatorDictionary<T> : Sequence {
         innerDictionary.removeAll()        
     }
     
-    public mutating func removeValueForKey(_ key: ValidatableField) {
+    public mutating func removeValueForKey(_ key: Validatable) {
         innerDictionary.removeValue(forKey: ObjectIdentifier(key))
     }
     

--- a/SwiftValidator/Rules/ConfirmRule.swift
+++ b/SwiftValidator/Rules/ConfirmRule.swift
@@ -15,7 +15,7 @@ import UIKit
  */
 public class ConfirmationRule: Rule {
     /// parameter confirmField: field to which original text field will be compared to.
-    private let confirmField: ValidatableField
+    private let confirmField: Validatable
     /// parameter message: String of error message.
     private var message : String
     
@@ -26,7 +26,7 @@ public class ConfirmationRule: Rule {
      - parameter message: String of error message.
      - returns: An initialized object, or nil if an object could not be created for some reason that would not result in an exception.
      */
-    public init(confirmField: ValidatableField, message : String = "This field does not match"){
+    public init(confirmField: Validatable, message : String = "This field does not match"){
         self.confirmField = confirmField
         self.message = message
     }

--- a/SwiftValidator/Rules/ValidationRule.swift
+++ b/SwiftValidator/Rules/ValidationRule.swift
@@ -13,7 +13,7 @@ import UIKit
  */
 public class ValidationRule {
     /// the field of the field
-    public var field:ValidatableField
+    public var field:Validatable
     /// the errorLabel of the field
     public var errorLabel:UILabel?
     /// the rules of the field
@@ -27,7 +27,7 @@ public class ValidationRule {
      - parameter rules: array of Rule objects, which field will be validated against.
      - returns: An initialized `ValidationRule` object, or nil if an object could not be created for some reason that would not result in an exception.
      */
-    public init(field: ValidatableField, rules:[Rule], errorLabel:UILabel?){
+    public init(field: Validatable, rules:[Rule], errorLabel:UILabel?){
         self.field = field
         self.errorLabel = errorLabel
         self.rules = rules


### PR DESCRIPTION
Hi,

I've recently had the pleasure to use SwiftValidator in my own project and I've run into a couple issues, so here are my fixes for them:

1. Makes `Validator` an open class to it can be inherited from and modified for your own needs.
2. Removes the weird `fields` property from `Validator` which made completely no sense.
3. Removes the `ValidatableField` typealias by making `Validatable` protocol available only to classes.